### PR TITLE
added try-catch block in copyNodes methods

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Ignores broken nodes and relationships.
 Also useful to skip no longer wanted properties or relationships with a certain type. Good for store compaction as it
 rewrites the store file reclaiming space that is sitting empty.
 
-Change the Neo4j version in pom.xml before running. (Currently 2.2.1)
+Change the Neo4j version in pom.xml before running. (Currently 2.2.4)
 
 ### Store Copy
 


### PR DESCRIPTION
We noticed that we are running into the following exception when trying to recreate our faulty db.

```
[INFO] An exception occured while executing the Java class. null

DynamicRecord Not in use, blockId[86177]
```

This merge adds a try-catch block in the copyNodes to resume copying when an exception is thrown, similar to the copyRelationships method.
