### PR TITLE
Vastly improve compaction of relationship store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 *.ipr
 .idea
 
+/bin/

--- a/src/main/java/org/neo4j/tool/StoreCopy.java
+++ b/src/main/java/org/neo4j/tool/StoreCopy.java
@@ -18,8 +18,6 @@ import org.neo4j.unsafe.batchinsert.BatchInserter;
 import org.neo4j.unsafe.batchinsert.BatchInserters;
 import org.neo4j.unsafe.batchinsert.BatchRelationship;
 
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -258,7 +256,7 @@ public class StoreCopy {
                     return _value++;
                 }
                 public void remove() {
-                    throw new NotImplementedException();
+                    throw new UnsupportedOperationException();
                 }
             };
         } else {
@@ -271,7 +269,7 @@ public class StoreCopy {
                     return pli.next();
                 }
                 public void remove() {
-                    throw new NotImplementedException();
+                    throw new UnsupportedOperationException();
                 }
             };
         }


### PR DESCRIPTION
The relationship store can become very sparse.  By iterating over every
possible relationship id, you have to handle many relationship ids not
being found.  This change keeps track of all the relationship IDs seen
while copying nodes and then only copies those relationships.  In a
consistent database, this has the same effect as iterating over
every possible relationship id.

This improved my relationship compaction time from 45 minutes to just
over 2 minutes.  This example had a 38GB neostore.relationshipstore.db
and it reduced to 129MB.  This was a > 99% compaction.
