### PR TITLE
StoreComparer: add missing transaction wrapping.

### DIFF
--- a/src/main/java/org/neo4j/tool/StoreComparer.java
+++ b/src/main/java/org/neo4j/tool/StoreComparer.java
@@ -57,9 +57,12 @@ public class StoreComparer {
         GraphDatabaseService targetDb = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder(target.getAbsolutePath()).setConfig(config()).newGraphDatabase();
         GraphDatabaseService sourceDb = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder(sourceDir).setConfig(config()).newGraphDatabase();
 
-        compareCounts(sourceDb, targetDb, ignoreRelTypes, ignoreProperties);
-        compareNodes(sourceDb, targetDb, ignoreProperties);
-        compareRelationships(sourceDb, targetDb, ignoreRelTypes, ignoreProperties);
+        try (Transaction srcDbTx = sourceDb.beginTx();
+             Transaction targetDbTx = targetDb.beginTx()) {
+            compareCounts(sourceDb, targetDb, ignoreRelTypes, ignoreProperties);
+            compareNodes(sourceDb, targetDb, ignoreProperties);
+            compareRelationships(sourceDb, targetDb, ignoreRelTypes, ignoreProperties);
+        }
 
         targetDb.shutdown();
         sourceDb.shutdown();


### PR DESCRIPTION
Fixes:

```
org.neo4j.graphdb.NotInTransactionException
    at org.neo4j.kernel.impl.core.ThreadToStatementContextBridge.assertInUnterminatedTransaction(ThreadToStatementContextBridge.java:71)
    at org.neo4j.kernel.impl.core.ThreadToStatementContextBridge.assertInUnterminatedTransaction(ThreadToStatementContextBridge.java:82)
    at org.neo4j.tooling.GlobalGraphOperations.assertInUnterminatedTransaction(GlobalGraphOperations.java:347)
    at org.neo4j.tooling.GlobalGraphOperations.getAllNodes(GlobalGraphOperations.java:91)
    at org.neo4j.kernel.impl.factory.GraphDatabaseFacade.getAllNodes(GraphDatabaseFacade.java:356)
    at org.neo4j.tool.StoreComparer.count(StoreComparer.java:84)
    at org.neo4j.tool.StoreComparer.compareCounts(StoreComparer.java:71)
    at org.neo4j.tool.StoreComparer.compareStore(StoreComparer.java:60)
    at org.neo4j.tool.StoreComparer.main(StoreComparer.java:43)
    ... 6 more
```
