### PR TITLE
[Bugfix] Correctly create copiedNodes map when `keep_node_ids` is false

### DIFF
--- a/src/main/java/org/neo4j/tool/StoreCopy.java
+++ b/src/main/java/org/neo4j/tool/StoreCopy.java
@@ -234,7 +234,7 @@ public class StoreCopy {
     }
 
     private static LongLongMap copyNodes(BatchInserter sourceDb, BatchInserter targetDb, Set<String> ignoreProperties, Set<String> ignoreLabels, Set<String> deleteNodesWithLabels, long highestNodeId, Flusher flusher, boolean stableNodeIds) {
-        MutableLongLongMap copiedNodes = stableNodeIds ? new LongLongHashMap() : null;
+        MutableLongLongMap copiedNodes = stableNodeIds ? null : new LongLongHashMap(10_000_000);
         long time = System.currentTimeMillis();
         long node = 0;
         long notFound = 0;


### PR DESCRIPTION
Commit https://github.com/jexp/store-utils/commit/1c097cae4f46f0e07006c12e9921edf1d860db2e introduced a bug when running the StoryCopy util with `keep_node_ids` set to `false`.

In the `copyNodes(...)` method the `MutableLongLongMap copiedNodes` is now initialized with a `null` value when `stableNodeIds` is `false`, but it should be the other way around (when using stable node IDs, i.e. `keep_node_ids` is `true`, there's no need to keep track of copied node IDs, but when NOT using stable node IDs, the map should be initialized to keep track of the mapping between old and new IDs).

Because the node IDs are not tracked correctly, the correct node IDs cannot be determined when creating the relationships later, resulting in the wrong relationships being created (in case the 'old' node IDs happen to coincidentally match with some new node), or no relationship being created at all (if the old node ID no longer maps to a node in the new graph).

This fix corrects this behaviour. I've also re-added the `initialCapacity` value of `10_000_000`, which was there originally before the above mentioned commit.