### PR TITLE
Fix link to official copy tool

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Please download a released version, else you must have Apache Maven. (Apache Mav
 
 ## Tool to copy Neo4j Stores
 
-From Neo4j 4.0 please use the [official tool](https://neo4j.com/docs/operations-manual/4.0/tools/copy/) that has the same capabilities.
+From Neo4j 4.0 please use the [official tool](https://neo4j.com/docs/operations-manual/current/backup-restore/copy-database/) that has the same capabilities.
 
 Uses the BatchInserterImpl to read a store and write the target store keeping the node-ids.
 Copies the manual (legacy) index-files as is, please note it performs no index upgrade!


### PR DESCRIPTION
The link to the official copy tool currently leads to a 404 page. This outdated link is replaced by a new link.